### PR TITLE
v.1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ---
 
 
+### v1.0.13 (17/03/2025)
+
+---
+
+- Global css import for quill editor is moved to new `WysiwygContent` component to only load the css when the component is used.
+- Introduced a new component `WysiwygContent` for displaying wyiswyg contents
+
+**Breaking Change**
+- Using `v-html` to display the wysiwyg content will still work, but it will no more have the wysiwyg styles `headings, aligments etc...`
+- Use the new introduced component to display the wysiwyg content
+  `<gWysiwygContent :html-content="html" />`
+
+
 ### v1.0.12 (31/01/2025)
 
 ---

--- a/components/WysiwygContent.vue
+++ b/components/WysiwygContent.vue
@@ -1,0 +1,40 @@
+<template>
+  <div :class="[wrapperDefaultClasses, wrapperClasses]">
+    <component :is="tag" :class="[defaultClasses, classes]" v-html="htmlContent"></component>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "WysiwygContent",
+  props: {
+    tag: {
+      type: String,
+      default: "div"
+    },
+    htmlContent: {
+      type: String,
+      default: ""
+    },
+    wrapperDefaultClasses: {
+      type: String,
+      default: "ql-snow"
+    },
+    wrapperClasses: {
+      type: String,
+      default: ""
+    },
+    defaultClasses: {
+      type: String,
+      default: "ql-editor"
+    },
+    classes: {
+      type: String,
+      default: ""
+    }
+  },
+  created() {
+    import("quill/dist/quill.snow.css");
+  }
+}
+</script>

--- a/components/wysiwyg.vue
+++ b/components/wysiwyg.vue
@@ -137,6 +137,7 @@ export default {
     }
   },
   created() {
+    import("quill/dist/quill.snow.css");
     if (process.client) {
       let Emoji = require("quill-emoji");
       let Quill = require('quill');

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,7 +20,7 @@ export default {
 
   // Plugins to run before rendering page:  https://go.nuxtjs.dev/config-plugins
   plugins: [
-    { src: '~/plugins/quill-editor', ssr: false }
+
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geeks.solutions/vue-components",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@geeks.solutions/vue-components",
-      "version": "1.0.11",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
         "@nuxt/content": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geeks.solutions/vue-components",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": "Geeks Solutions info@geeks.solutions (https://www.geeks.solutions)",
   "repository": {
     "type": "git",

--- a/plugins/quill-editor.js
+++ b/plugins/quill-editor.js
@@ -1,1 +1,0 @@
-import "quill/dist/quill.snow.css";


### PR DESCRIPTION
- [ ] Global css import for quill editor is moved to new `WysiwygContent` component to only load the css when the component is used