### PR TITLE
For the button option added to the wysiwyg, when using Sections CSS or Sober Css, the style of the button should match the style of the CSS used #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - Update quill anchor tags to behavior similar to the nuxt-links behavior
 
-- Update quill toolbar options order: Review of the wysiwyg component #108
+- Update quill toolbar options order: Review of the wysiwyg component #108 
 
 ### v1.0.15 (03/04/2025)
 

--- a/components/WysiwygContent.vue
+++ b/components/WysiwygContent.vue
@@ -121,11 +121,8 @@ button.quill-button-container {
   transition: background-color 0.3s;
   display: inline-block;
 }
-.quill-button-container:hover {
-  background-color: #e9e9e9;
-}
 .ql-a-button {
-  color: #000 !important;
+  color: inherit !important;
   text-decoration: none !important;
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
For the button option added to the wysiwyg, when using Sections CSS or Sober Css, the style of the button should match the style of the CSS used https://github.com/Geeks-Solutions/sections-cms/issues/52