### PR TITLE
V.1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ---
 
 
+### v1.0.19 (18/04/2025)
+
+---
+
+- Fix quill word wrap default styling to `word-wrap: normal;`
+
+
 ### v1.0.18 (15/04/2025)
 
 ---

--- a/components/WysiwygContent.vue
+++ b/components/WysiwygContent.vue
@@ -144,4 +144,7 @@ button.quill-button-container {
 .ql-editor p {
   font-size: 1rem;
 }
+div .ql-editor {
+  word-wrap: normal;
+}
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geeks.solutions/vue-components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "author": "Geeks Solutions info@geeks.solutions (https://www.geeks.solutions)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [ ] Fix quill word wrap default styling to `word-wrap: normal;`